### PR TITLE
文章生成処理に上限の試行回数を設定

### DIFF
--- a/cmd/lambda/main_test.go
+++ b/cmd/lambda/main_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/paralleltree/markov-bot-go/config"
+	"github.com/paralleltree/markov-bot-go/handler"
 	"github.com/paralleltree/markov-bot-go/lib"
 )
 
@@ -30,6 +32,28 @@ func TestRun_WhenModelNotExists_CreatesModel(t *testing.T) {
 	}
 	if inputText != postClient.PostedContents[0] {
 		t.Errorf("unexpected output: want %s, but got %s", inputText, postClient.PostedContents[0])
+	}
+}
+
+func TestRun_WhenModelIsEmpty_ReturnsGenerateFailedError(t *testing.T) {
+	// arrange
+	postClient := NewRecordableBlogClient(nil)
+	conf := &config.BotConfig{
+		FetchClient: NewRecordableBlogClient(nil),
+		PostClient:  postClient,
+		ChainConfig: config.DefaultChainConfig(),
+	}
+	store := NewMemoryStore()
+
+	// act
+	err := run(conf, store)
+
+	// assert
+	if err == nil {
+		t.Errorf("run() should return error, but got nil")
+	}
+	if !errors.Is(err, handler.ErrGenerationFailed) {
+		t.Errorf("run() should return ErrGenerateFailed, but got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## 変更点
* 文章生成処理ハンドラでの試行回数に上限を設定した
  * 空のモデルや最小単語数を満たせない結果のみしか得られない場合に無限ループを引き起こしていたため