### PR TITLE
モデルが存在する場合にモデル再生成時のエラーをスルーさせる

### DIFF
--- a/cmd/lambda/main_test.go
+++ b/cmd/lambda/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"errors"
+	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -27,10 +29,8 @@ func TestRun_WhenModelNotExists_CreatesModel(t *testing.T) {
 	}
 
 	// assert
-	if len(postClient.PostedContents) != 1 {
-		t.Errorf("PostedContents should have 1 item, but got: %v", postClient.PostedContents)
-	}
-	if inputText != postClient.PostedContents[0] {
+	wantResult := []string{inputText}
+	if !reflect.DeepEqual(wantResult, postClient.PostedContents) {
 		t.Errorf("unexpected output: want %s, but got %s", inputText, postClient.PostedContents[0])
 	}
 }
@@ -54,6 +54,43 @@ func TestRun_WhenModelIsEmpty_ReturnsGenerateFailedError(t *testing.T) {
 	}
 	if !errors.Is(err, handler.ErrGenerationFailed) {
 		t.Errorf("run() should return ErrGenerateFailed, but got: %v", err)
+	}
+}
+
+func TestRun_WhenModelAlreadyExistsAndBuildingModelFails_PostsWithExistingModelAndReturnsNoError(t *testing.T) {
+	// arrange
+	inputText := "アルミ缶の上にあるミカン"
+	postClient := NewRecordableBlogClient(nil)
+	conf := &config.BotConfig{
+		FetchClient: NewRecordableBlogClient([]string{inputText}),
+		PostClient:  NewRecordableBlogClient(nil), // discard posted content
+		ChainConfig: config.DefaultChainConfig(),
+	}
+	store := NewMemoryStore()
+
+	// build model
+	if err := run(conf, store); err != nil {
+		t.Errorf("run() should not return error, but got: %v", err)
+	}
+
+	conf = &config.BotConfig{
+		FetchClient: &errorBlogClient{},
+		PostClient:  postClient,
+		ChainConfig: config.ChainConfig{
+			FetchStatusCount: 1,
+			ExpiresIn:        0, // force building chain
+		},
+	}
+
+	// act
+	if err := run(conf, store); err != nil {
+		t.Errorf("run() should not return error, but got: %v", err)
+	}
+
+	// assert
+	wantResult := []string{inputText}
+	if !reflect.DeepEqual(wantResult, postClient.PostedContents) {
+		t.Errorf("unexpected output: want %s, but got %s", inputText, postClient.PostedContents[0])
 	}
 }
 
@@ -82,6 +119,18 @@ func (f *recordableBlogClient) GetPostsFetcher() lib.ChunkIteratorFunc[string] {
 func (f *recordableBlogClient) CreatePost(body string) error {
 	f.PostedContents = append(f.PostedContents, body)
 	return nil
+}
+
+type errorBlogClient struct{}
+
+func (e *errorBlogClient) GetPostsFetcher() lib.ChunkIteratorFunc[string] {
+	return func() ([]string, bool, error) {
+		return nil, false, fmt.Errorf("failed to fetch posts")
+	}
+}
+
+func (e *errorBlogClient) CreatePost(body string) error {
+	return fmt.Errorf("failed to create post")
 }
 
 type memoryStore struct {


### PR DESCRIPTION
## 変更点
* 文章生成時にモデル更新に失敗した場合、全体の処理を終了させず既存のモデルを利用して投稿するように変更
  * 何らかの原因でソース投稿にアクセスできなくなっても投稿は可能な状態にしたい
  * モデル更新に失敗した場合は標準エラーに出力する
  * モデル未構築の場合にモデル生成に失敗した場合はエラーとして終了させる
* 空のモデルの場合に文章生成処理が無限ループとならないよう、上限の試行回数で打ち切るように修正

## 備考
* モデル生成と文章生成を同時にするとどちらかがエラーとなったときに気づきにくいため、個別のサブコマンドのみ提供する形のほうが望ましいかもしれない
  * この場合`ExpiresIn`の管理をやめるべき